### PR TITLE
Change exception system

### DIFF
--- a/kformat/__init__.py
+++ b/kformat/__init__.py
@@ -1,7 +1,13 @@
+from .exception import *
 from .kclass import *
 from .kproperty import *
 
-
-__all__ = ['kclass', 'N', 'AN']
+__all__ = [
+    'kclass',
+    'N',
+    'AN',
+    'KFormatError',
+    'TooLongValueError',
+]
 
 __version__ = '0.3.0'

--- a/kformat/__init__.py
+++ b/kformat/__init__.py
@@ -7,6 +7,7 @@ __all__ = [
     'N',
     'AN',
     'KFormatError',
+    'WrongTypeError',
     'TooLongValueError',
 ]
 

--- a/kformat/__init__.py
+++ b/kformat/__init__.py
@@ -7,7 +7,7 @@ __all__ = [
     'N',
     'AN',
     'KFormatError',
-    'WrongTypeError',
+    'UnexpectedTypeError',
     'TooLongValueError',
 ]
 

--- a/kformat/__init__.py
+++ b/kformat/__init__.py
@@ -8,7 +8,7 @@ __all__ = [
     'AN',
     'KFormatError',
     'UnexpectedTypeError',
-    'TooLongValueError',
+    'InvalidLengthError',
 ]
 
 __version__ = '0.3.0'

--- a/kformat/exception.py
+++ b/kformat/exception.py
@@ -12,13 +12,13 @@ class KFormatError(Exception):
 
 
 class WrongTypeError(KFormatError):
-    def __init__(self, expect: Type, value):
+    def __init__(self, expected: Type, value):
         super().__init__()
-        self.expect = expect
+        self.expected = expected
         self.value = value
 
     def __str__(self) -> str:
-        return f'Should be "{_name(self.expect)}" instead of "{_name(self.value)}"'
+        return f'"{_name(self.expected)}" is expected, but "{_name(self.value)}" is given'
 
 
 class TooLongValueError(KFormatError):

--- a/kformat/exception.py
+++ b/kformat/exception.py
@@ -1,6 +1,6 @@
 from typing import Type
 
-__all__ = ['KFormatError', 'UnexpectedTypeError', 'TooLongValueError']
+__all__ = ['KFormatError', 'UnexpectedTypeError', 'InvalidLengthError']
 
 
 def _name(type_: Type) -> str:
@@ -21,7 +21,7 @@ class UnexpectedTypeError(KFormatError):
         return f'"{_name(self.expected)}" is expected, but "{_name(self.value)}" is given'
 
 
-class TooLongValueError(KFormatError):
+class InvalidLengthError(KFormatError):
     def __init__(self, length: int):
         super().__init__()
         self.length = length

--- a/kformat/exception.py
+++ b/kformat/exception.py
@@ -18,7 +18,10 @@ class UnexpectedTypeError(KFormatError):
         self.value = value
 
     def __str__(self) -> str:
-        return f'"{_name(self.expected)}" is expected, but "{_name(self.value)}" is given'
+        return (
+            f'"{_name(self.expected)}" is expected, '
+            f'but "{_name(self.value)}" is given'
+        )
 
 
 class InvalidLengthError(KFormatError):
@@ -27,4 +30,4 @@ class InvalidLengthError(KFormatError):
         self.length = length
 
     def __str__(self) -> str:
-        return f'Too long value is given(max: {self.length})'
+        return f'Invalid length of value is given(expected: {self.length})'

--- a/kformat/exception.py
+++ b/kformat/exception.py
@@ -1,0 +1,16 @@
+from typing import Type
+
+__all__ = ['KFormatError', 'TooLongValueError']
+
+
+class KFormatError(Exception):
+    pass
+
+
+class TooLongValueError(KFormatError):
+    def __init__(self, length: int):
+        super().__init__()
+        self.length = length
+
+    def __str__(self) -> str:
+        return f'Too long value is given(max: {self.length})'

--- a/kformat/exception.py
+++ b/kformat/exception.py
@@ -1,6 +1,6 @@
 from typing import Type
 
-__all__ = ['KFormatError', 'WrongTypeError', 'TooLongValueError']
+__all__ = ['KFormatError', 'UnexpectedTypeError', 'TooLongValueError']
 
 
 def _name(type_: Type) -> str:
@@ -11,7 +11,7 @@ class KFormatError(Exception):
     pass
 
 
-class WrongTypeError(KFormatError):
+class UnexpectedTypeError(KFormatError):
     def __init__(self, expected: Type, value):
         super().__init__()
         self.expected = expected

--- a/kformat/exception.py
+++ b/kformat/exception.py
@@ -1,10 +1,24 @@
 from typing import Type
 
-__all__ = ['KFormatError', 'TooLongValueError']
+__all__ = ['KFormatError', 'WrongTypeError', 'TooLongValueError']
+
+
+def _name(type_: Type) -> str:
+    return type_.__name__ if hasattr(type_, '__name__') else str(type_)
 
 
 class KFormatError(Exception):
     pass
+
+
+class WrongTypeError(KFormatError):
+    def __init__(self, expect: Type, value):
+        super().__init__()
+        self.expect = expect
+        self.value = value
+
+    def __str__(self) -> str:
+        return f'Should be "{_name(self.expect)}" instead of "{_name(self.value)}"'
 
 
 class TooLongValueError(KFormatError):

--- a/kformat/kclass.py
+++ b/kformat/kclass.py
@@ -7,10 +7,26 @@ __all__ = ['kclass']
 KCLASS_ANNOTATION = '__kclass__'
 
 
+def _is_prop_kclass(prop) -> bool:
+    return getattr(prop, KCLASS_ANNOTATION, False)
+
+
+def _is_prop_list(prop) -> bool:
+    return hasattr(prop, '__origin__') and prop.__origin__ == list
+
+
 def _kclass(cls):
     setattr(cls, KCLASS_ANNOTATION, True)
 
-    props = [(k, prop) for (k, prop) in cls.__annotations__.items()]
+    props = list(cls.__annotations__.items())
+
+    for _, prop in props:
+        if (
+            not _is_prop_kclass(prop)
+            and not _is_prop_list(prop)
+            and not isinstance(prop, kproperty.KProperty)
+        ):
+            raise WrongTypeError(kproperty.KProperty, prop.__name__)
 
     @property
     def to_bytes(self):
@@ -20,11 +36,11 @@ def _kclass(cls):
         prop_bytes = []
 
         for ((k, prop), v) in zip(props, args):
-            if hasattr(prop, KCLASS_ANNOTATION) and prop.__kclass__:
+            if _is_prop_kclass(prop):
                 if not isinstance(v, prop):
                     raise WrongTypeError(prop, type(v))
                 prop_bytes.append(v.bytes)
-            elif hasattr(prop, '__origin__') and prop.__origin__ == list:
+            elif _is_prop_list(prop):
                 if not isinstance(v, list):
                     raise WrongTypeError(list, type(v))
                 for item in v:
@@ -34,8 +50,6 @@ def _kclass(cls):
                         )
                 prop_bytes.extend(c.bytes for c in v)
             else:
-                if not isinstance(prop, kproperty.KProperty):
-                    raise WrongTypeError(kproperty.KProperty, prop.__name__)
                 if type(v) not in prop.expected_types:
                     expects = ', '.join(
                         sorted(t.__name__ for t in prop.expected_types)

--- a/kformat/kclass.py
+++ b/kformat/kclass.py
@@ -1,5 +1,5 @@
-from . import kproperty
 from .exception import UnexpectedTypeError
+from .kproperty import KProperty
 
 __all__ = ['kclass']
 
@@ -15,18 +15,22 @@ def _is_prop_list(prop) -> bool:
     return hasattr(prop, '__origin__') and prop.__origin__ == list
 
 
+def _is_valid_child_prop(prop) -> bool:
+    return (
+        _is_prop_kclass(prop)
+        or _is_prop_list(prop)
+        or isinstance(prop, KProperty)
+    )
+
+
 def _kclass(cls):
     setattr(cls, KCLASS_ANNOTATION, True)
 
     props = list(cls.__annotations__.items())
 
     for _, prop in props:
-        if (
-            not _is_prop_kclass(prop)
-            and not _is_prop_list(prop)
-            and not isinstance(prop, kproperty.KProperty)
-        ):
-            raise UnexpectedTypeError(kproperty.KProperty, prop.__name__)
+        if not _is_valid_child_prop(prop):
+            raise UnexpectedTypeError(KProperty, prop.__name__)
 
     @property
     def to_bytes(self):
@@ -44,17 +48,17 @@ def _kclass(cls):
                 if not isinstance(v, list):
                     raise UnexpectedTypeError(list, type(v))
                 for item in v:
-                    if not getattr(item, KCLASS_ANNOTATION, False):
+                    if not _is_prop_kclass(item):
                         raise UnexpectedTypeError(
                             f'List[{prop.__args__[0].__name__}]', type(item)
                         )
                 prop_bytes.extend(c.bytes for c in v)
             else:
                 if type(v) not in prop.expected_types:
-                    expects = ', '.join(
+                    expected_types = ', '.join(
                         sorted(t.__name__ for t in prop.expected_types)
                     )
-                    raise UnexpectedTypeError(expects, type(v))
+                    raise UnexpectedTypeError(expected_types, type(v))
                 prop_bytes.append(prop.to_bytes(v))
 
             setattr(self, k, (prop, v))

--- a/kformat/kclass.py
+++ b/kformat/kclass.py
@@ -1,6 +1,5 @@
 from . import kproperty
 
-
 __all__ = ['kclass']
 
 
@@ -21,8 +20,9 @@ def _kclass(cls):
 
         for ((k, prop), v) in zip(props, args):
             if hasattr(prop, KCLASS_ANNOTATION) and prop.__kclass__:
-                assert isinstance(v, prop), \
-                    f'{type(v).__name__} is not type of {prop.__name__}'
+                assert isinstance(
+                    v, prop
+                ), f'{type(v).__name__} is not type of {prop.__name__}'
                 prop_bytes.append(v.bytes)
             elif hasattr(prop, '__origin__') and prop.__origin__ == list:
                 assert isinstance(v, list), f'{type(v).__name__} is not List'
@@ -31,11 +31,13 @@ def _kclass(cls):
                 ), f'All of list items should be type of K-Class'
                 prop_bytes.extend(c.bytes for c in v)
             else:
-                assert isinstance(prop, kproperty.KProperty), \
-                    f'{prop.__name__} is not subtype of KProperty'
-                assert type(v) in prop.expected_types, \
-                    f'{prop.__class__.__name__} cannot ' \
+                assert isinstance(
+                    prop, kproperty.KProperty
+                ), f'{prop.__name__} is not subtype of KProperty'
+                assert type(v) in prop.expected_types, (
+                    f'{prop.__class__.__name__} cannot '
                     f'accept {type(v).__name__} type'
+                )
                 prop_bytes.append(prop.to_bytes(v))
 
             setattr(self, k, (prop, v))

--- a/kformat/kclass.py
+++ b/kformat/kclass.py
@@ -1,5 +1,5 @@
 from . import kproperty
-from .exception import WrongTypeError
+from .exception import UnexpectedTypeError
 
 __all__ = ['kclass']
 
@@ -26,7 +26,7 @@ def _kclass(cls):
             and not _is_prop_list(prop)
             and not isinstance(prop, kproperty.KProperty)
         ):
-            raise WrongTypeError(kproperty.KProperty, prop.__name__)
+            raise UnexpectedTypeError(kproperty.KProperty, prop.__name__)
 
     @property
     def to_bytes(self):
@@ -38,14 +38,14 @@ def _kclass(cls):
         for ((k, prop), v) in zip(props, args):
             if _is_prop_kclass(prop):
                 if not isinstance(v, prop):
-                    raise WrongTypeError(prop, type(v))
+                    raise UnexpectedTypeError(prop, type(v))
                 prop_bytes.append(v.bytes)
             elif _is_prop_list(prop):
                 if not isinstance(v, list):
-                    raise WrongTypeError(list, type(v))
+                    raise UnexpectedTypeError(list, type(v))
                 for item in v:
                     if not getattr(item, KCLASS_ANNOTATION, False):
-                        raise WrongTypeError(
+                        raise UnexpectedTypeError(
                             f'List[{prop.__args__[0].__name__}]', type(item)
                         )
                 prop_bytes.extend(c.bytes for c in v)
@@ -54,7 +54,7 @@ def _kclass(cls):
                     expects = ', '.join(
                         sorted(t.__name__ for t in prop.expected_types)
                     )
-                    raise WrongTypeError(expects, type(v))
+                    raise UnexpectedTypeError(expects, type(v))
                 prop_bytes.append(prop.to_bytes(v))
 
             setattr(self, k, (prop, v))

--- a/kformat/kproperty.py
+++ b/kformat/kproperty.py
@@ -2,6 +2,8 @@ import abc
 from datetime import date, time
 from typing import Optional, Set
 
+from .exception import TooLongValueError
+
 __all__ = ['AN', 'N']
 
 
@@ -50,15 +52,12 @@ class N(KProperty):
         except TypeError:
             p, s = b'', ''
 
-        try:
-            b = p + bytes(s, encoding=N.ENCODING).rjust(
-                self.length - len(p),
-                self.filler
-            )
-            assert len(b) <= self.length
-            return b
-        except AssertionError:
-            raise ValueError(f'Too long value is given(max: {self.length})')
+        b = p + bytes(s, encoding=N.ENCODING).rjust(
+            self.length - len(p), self.filler
+        )
+        if len(b) > self.length:
+            raise TooLongValueError(self.length)
+        return b
 
 
 class AN(KProperty):
@@ -92,10 +91,7 @@ class AN(KProperty):
         else:
             s = str(int(v))
 
-        try:
-            b = bytes(s, encoding=AN.ENCODING).ljust(self.length, self.filler)
-            assert len(b) <= self.length
-            return b
-        except AssertionError:
-            raise ValueError(f'Too long value is given(max: {self.length})')
-
+        b = bytes(s, encoding=AN.ENCODING).ljust(self.length, self.filler)
+        if len(b) > self.length:
+            raise TooLongValueError(self.length)
+        return b

--- a/kformat/kproperty.py
+++ b/kformat/kproperty.py
@@ -11,12 +11,8 @@ TYPES = Set[type]
 
 
 class KProperty(metaclass=abc.ABCMeta):
-
     def __init__(
-        self,
-        length: int,
-        expected_types: TYPES,
-        filler: bytes
+        self, length: int, expected_types: TYPES, filler: bytes
     ) -> None:
         self.length = length
         self.expected_types = expected_types
@@ -33,17 +29,8 @@ class N(KProperty):
     FILLER = b'0'
     ENCODING = 'ascii'
 
-    def __init__(
-        self,
-        length: int,
-        *,
-        filler: Optional[bytes]=None
-    ) -> None:
-        super().__init__(
-            length,
-            N.EXPECTED_TYPES,
-            filler or N.FILLER
-        )
+    def __init__(self, length: int, *, filler: Optional[bytes] = None) -> None:
+        super().__init__(length, N.EXPECTED_TYPES, filler or N.FILLER)
 
     def to_bytes(self, v: Optional) -> bytes:
         try:
@@ -69,17 +56,8 @@ class AN(KProperty):
     TIME_FORMAT = '%H%M%S%f'
     TIME_FORMAT_SLICE = 0, -2
 
-    def __init__(
-        self,
-        length: int,
-        *,
-        filler: Optional[bytes]=None
-    ) -> None:
-        super().__init__(
-            length,
-            AN.EXPECTED_TYPES,
-            filler or AN.FILLER
-        )
+    def __init__(self, length: int, *, filler: Optional[bytes] = None) -> None:
+        super().__init__(length, AN.EXPECTED_TYPES, filler or AN.FILLER)
 
     def to_bytes(self, v: Optional) -> bytes:
         if v is None or isinstance(v, str):

--- a/kformat/kproperty.py
+++ b/kformat/kproperty.py
@@ -2,7 +2,7 @@ import abc
 from datetime import date, time
 from typing import Optional, Set
 
-from .exception import TooLongValueError
+from .exception import InvalidLengthError
 
 __all__ = ['AN', 'N']
 
@@ -43,7 +43,7 @@ class N(KProperty):
             self.length - len(p), self.filler
         )
         if len(b) > self.length:
-            raise TooLongValueError(self.length)
+            raise InvalidLengthError(self.length)
         return b
 
 
@@ -71,5 +71,5 @@ class AN(KProperty):
 
         b = bytes(s, encoding=AN.ENCODING).ljust(self.length, self.filler)
         if len(b) > self.length:
-            raise TooLongValueError(self.length)
+            raise InvalidLengthError(self.length)
         return b

--- a/tests/test_kclass.py
+++ b/tests/test_kclass.py
@@ -88,13 +88,13 @@ class TestWrongTypeInit:
         assert str(e.value) == 'Should be "List[Other]" instead of "int"'
 
     def test_prop_is_not_k_property(self):
-        @kclass
-        class One:
-            an: AN(10)
-            n: int
-
         with pytest.raises(WrongTypeError) as e:
-            One(1, 2)
+
+            @kclass
+            class One:
+                an: AN(10)
+                n: int
+
         assert str(e.value) == 'Should be "KProperty" instead of "int"'
 
     def test_prop_is_not_expected_type(self):

--- a/tests/test_kclass.py
+++ b/tests/test_kclass.py
@@ -1,5 +1,5 @@
-from unittest.mock import patch
 from typing import List
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_kclass.py
+++ b/tests/test_kclass.py
@@ -75,17 +75,17 @@ class TestWrongTypeInit:
     def test_prop_is_not_kclass(self):
         with pytest.raises(UnexpectedTypeError) as e:
             self.something(1, [1, 2])
-        assert str(e.value) == 'Should be "Other" instead of "int"'
+        assert str(e.value) == '"Other" is expected, but "int" is given'
 
     def test_prop_is_not_list(self):
         with pytest.raises(UnexpectedTypeError) as e:
             self.something(self.other(1, 2), 3)
-        assert str(e.value) == 'Should be "list" instead of "int"'
+        assert str(e.value) == '"list" is expected, but "int" is given'
 
     def test_all_items_are_not_kclass(self):
         with pytest.raises(UnexpectedTypeError) as e:
             self.something(self.other(1, 2), [self.other(3, 4), 5])
-        assert str(e.value) == 'Should be "List[Other]" instead of "int"'
+        assert str(e.value) == '"List[Other]" is expected, but "int" is given'
 
     def test_prop_is_not_k_property(self):
         with pytest.raises(UnexpectedTypeError) as e:
@@ -95,16 +95,16 @@ class TestWrongTypeInit:
                 an: AN(10)
                 n: int
 
-        assert str(e.value) == 'Should be "KProperty" instead of "int"'
+        assert str(e.value) == '"KProperty" is expected, but "int" is given'
 
     def test_prop_is_not_expected_type(self):
         with pytest.raises(UnexpectedTypeError) as e:
             self.other(1, '2')
-        assert str(e.value) == 'Should be "float, int" instead of "str"'
+        assert str(e.value) == '"float, int" is expected, but "str" is given'
 
         with pytest.raises(UnexpectedTypeError) as e:
             self.other([1], 2)
-        assert (
-            str(e.value)
-            == 'Should be "NoneType, date, float, int, str, time" instead of "list"'
+        assert str(e.value) == (
+            '"NoneType, date, float, int, str, time" '
+            'is expected, but "list" is given'
         )

--- a/tests/test_kclass.py
+++ b/tests/test_kclass.py
@@ -1,6 +1,8 @@
 from unittest.mock import patch
 from typing import List
 
+import pytest
+
 from kformat.kclass import kclass
 from kformat.kproperty import AN, N
 
@@ -51,3 +53,54 @@ def test_list_of_kclass_creation():
 
     some_list = [Something(1), Something(2), Something(3)]
     assert b''.join(s.bytes for s in some_list) == b'123'
+
+
+class TestWrongTypeInit:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        @kclass
+        class Other:
+            an: AN(10)
+            n: N(5)
+
+        @kclass
+        class Something:
+            other: Other
+            others: List[Other]
+
+        self.other = Other
+        self.something = Something
+
+    def test_prop_is_not_kclass(self):
+        with pytest.raises(AssertionError) as e:
+            self.something(1, [1, 2])
+        assert str(e.value) == 'int is not type of Other'
+
+    def test_prop_is_not_list(self):
+        with pytest.raises(AssertionError) as e:
+            self.something(self.other(1, 2), 3)
+        assert str(e.value) == 'int is not List'
+
+    def test_all_items_are_not_kclass(self):
+        with pytest.raises(AssertionError) as e:
+            self.something(self.other(1, 2), [self.other(3, 4), 5])
+        assert str(e.value) == 'All of list items should be type of K-Class'
+
+    def test_prop_is_not_k_property(self):
+        @kclass
+        class One:
+            an: AN(10)
+            n: int
+
+        with pytest.raises(AssertionError) as e:
+            One(1, 2)
+        assert str(e.value) == 'int is not subtype of KProperty'
+
+    def test_prop_is_not_expected_type(self):
+        with pytest.raises(AssertionError) as e:
+            self.other(1, '2')
+        assert str(e.value) == 'N cannot accept str type'
+
+        with pytest.raises(AssertionError) as e:
+            self.other([1], 2)
+        assert str(e.value) == 'AN cannot accept list type'

--- a/tests/test_kclass.py
+++ b/tests/test_kclass.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
+from kformat.exception import WrongTypeError
 from kformat.kclass import kclass
 from kformat.kproperty import AN, N
 
@@ -72,19 +73,19 @@ class TestWrongTypeInit:
         self.something = Something
 
     def test_prop_is_not_kclass(self):
-        with pytest.raises(AssertionError) as e:
+        with pytest.raises(WrongTypeError) as e:
             self.something(1, [1, 2])
-        assert str(e.value) == 'int is not type of Other'
+        assert str(e.value) == 'Should be "Other" instead of "int"'
 
     def test_prop_is_not_list(self):
-        with pytest.raises(AssertionError) as e:
+        with pytest.raises(WrongTypeError) as e:
             self.something(self.other(1, 2), 3)
-        assert str(e.value) == 'int is not List'
+        assert str(e.value) == 'Should be "list" instead of "int"'
 
     def test_all_items_are_not_kclass(self):
-        with pytest.raises(AssertionError) as e:
+        with pytest.raises(WrongTypeError) as e:
             self.something(self.other(1, 2), [self.other(3, 4), 5])
-        assert str(e.value) == 'All of list items should be type of K-Class'
+        assert str(e.value) == 'Should be "List[Other]" instead of "int"'
 
     def test_prop_is_not_k_property(self):
         @kclass
@@ -92,15 +93,18 @@ class TestWrongTypeInit:
             an: AN(10)
             n: int
 
-        with pytest.raises(AssertionError) as e:
+        with pytest.raises(WrongTypeError) as e:
             One(1, 2)
-        assert str(e.value) == 'int is not subtype of KProperty'
+        assert str(e.value) == 'Should be "KProperty" instead of "int"'
 
     def test_prop_is_not_expected_type(self):
-        with pytest.raises(AssertionError) as e:
+        with pytest.raises(WrongTypeError) as e:
             self.other(1, '2')
-        assert str(e.value) == 'N cannot accept str type'
+        assert str(e.value) == 'Should be "float, int" instead of "str"'
 
-        with pytest.raises(AssertionError) as e:
+        with pytest.raises(WrongTypeError) as e:
             self.other([1], 2)
-        assert str(e.value) == 'AN cannot accept list type'
+        assert (
+            str(e.value)
+            == 'Should be "NoneType, date, float, int, str, time" instead of "list"'
+        )

--- a/tests/test_kclass.py
+++ b/tests/test_kclass.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from kformat.exception import WrongTypeError
+from kformat.exception import UnexpectedTypeError
 from kformat.kclass import kclass
 from kformat.kproperty import AN, N
 
@@ -73,22 +73,22 @@ class TestWrongTypeInit:
         self.something = Something
 
     def test_prop_is_not_kclass(self):
-        with pytest.raises(WrongTypeError) as e:
+        with pytest.raises(UnexpectedTypeError) as e:
             self.something(1, [1, 2])
         assert str(e.value) == 'Should be "Other" instead of "int"'
 
     def test_prop_is_not_list(self):
-        with pytest.raises(WrongTypeError) as e:
+        with pytest.raises(UnexpectedTypeError) as e:
             self.something(self.other(1, 2), 3)
         assert str(e.value) == 'Should be "list" instead of "int"'
 
     def test_all_items_are_not_kclass(self):
-        with pytest.raises(WrongTypeError) as e:
+        with pytest.raises(UnexpectedTypeError) as e:
             self.something(self.other(1, 2), [self.other(3, 4), 5])
         assert str(e.value) == 'Should be "List[Other]" instead of "int"'
 
     def test_prop_is_not_k_property(self):
-        with pytest.raises(WrongTypeError) as e:
+        with pytest.raises(UnexpectedTypeError) as e:
 
             @kclass
             class One:
@@ -98,11 +98,11 @@ class TestWrongTypeInit:
         assert str(e.value) == 'Should be "KProperty" instead of "int"'
 
     def test_prop_is_not_expected_type(self):
-        with pytest.raises(WrongTypeError) as e:
+        with pytest.raises(UnexpectedTypeError) as e:
             self.other(1, '2')
         assert str(e.value) == 'Should be "float, int" instead of "str"'
 
-        with pytest.raises(WrongTypeError) as e:
+        with pytest.raises(UnexpectedTypeError) as e:
             self.other([1], 2)
         assert (
             str(e.value)

--- a/tests/test_kproperty.py
+++ b/tests/test_kproperty.py
@@ -2,6 +2,7 @@ from datetime import date, time
 
 import pytest
 
+from kformat.exception import TooLongValueError
 from kformat.kproperty import AN, N
 
 
@@ -30,7 +31,7 @@ def test_N_to_bytes_with_filler(length, filler, value, expected):
 
 @pytest.mark.parametrize('length, value', [(3, 1234), (2, -10)])
 def test_N_to_bytes_with_invalid_length(length, value):
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(TooLongValueError) as e:
         assert N(length).to_bytes(value)
     assert 'Too long value is given' in str(e.value)
 
@@ -51,6 +52,6 @@ def test_AN_to_bytes(length, value, expected):
 
 
 def test_AN_to_bytes_with_invalid_length():
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(TooLongValueError) as e:
         assert AN(5).to_bytes(date(2018, 9, 9))
     assert 'Too long value is given' in str(e.value)

--- a/tests/test_kproperty.py
+++ b/tests/test_kproperty.py
@@ -2,7 +2,7 @@ from datetime import date, time
 
 import pytest
 
-from kformat.exception import TooLongValueError
+from kformat.exception import InvalidLengthError
 from kformat.kproperty import AN, N
 
 
@@ -31,7 +31,7 @@ def test_N_to_bytes_with_filler(length, filler, value, expected):
 
 @pytest.mark.parametrize('length, value', [(3, 1234), (2, -10)])
 def test_N_to_bytes_with_invalid_length(length, value):
-    with pytest.raises(TooLongValueError) as e:
+    with pytest.raises(InvalidLengthError) as e:
         assert N(length).to_bytes(value)
     assert 'Too long value is given' in str(e.value)
 
@@ -52,6 +52,6 @@ def test_AN_to_bytes(length, value, expected):
 
 
 def test_AN_to_bytes_with_invalid_length():
-    with pytest.raises(TooLongValueError) as e:
+    with pytest.raises(InvalidLengthError) as e:
         assert AN(5).to_bytes(date(2018, 9, 9))
     assert 'Too long value is given' in str(e.value)

--- a/tests/test_kproperty.py
+++ b/tests/test_kproperty.py
@@ -33,7 +33,7 @@ def test_N_to_bytes_with_filler(length, filler, value, expected):
 def test_N_to_bytes_with_invalid_length(length, value):
     with pytest.raises(InvalidLengthError) as e:
         assert N(length).to_bytes(value)
-    assert 'Too long value is given' in str(e.value)
+    assert 'Invalid length of value is given' in str(e.value)
 
 
 @pytest.mark.parametrize(
@@ -54,4 +54,4 @@ def test_AN_to_bytes(length, value, expected):
 def test_AN_to_bytes_with_invalid_length():
     with pytest.raises(InvalidLengthError) as e:
         assert AN(5).to_bytes(date(2018, 9, 9))
-    assert 'Too long value is given' in str(e.value)
+    assert 'Invalid length of value is given' in str(e.value)


### PR DESCRIPTION
> 이 PR은 breaking change를 포함하고 있습니다.

## 변경점

* 별도의 exception class를 만들었습니다.
* `kproperty`에서 길이가 맞지 않을 때 `ValueError` 대신 `KFormatError`를 상속받은 `TooLongValueError`를 raise합니다.
* `kclass`에서 발생하는 에러 메시지를 명시적으로 바꿔주었습니다.
	* 라이브러리 사용자에게 좋은 에러 메시지는 _왜 에러가 발생했는지_ 이상으로 _어떻게 해야 에러를 해결할 수 있는지_ 알려주는 메시지라고 생각했습니다.
	* 변경된 메시지 포맷은 https://github.com/Rainist/K-Format/commit/db00250c61afbb9d7ba67055222d6b85784a8285 커밋에서 확인 가능합니다.
	* `AN cannot accept ... type` 메시지가 좀 장황해진 느낌인데 코멘트 부탁드립니다.
* `kclass`의 property로 `KProperty`가 선언되지 않았을 때 발생하던 에러를 조기에 발생시킵니다.
	* as-is: 클래스 선언 후 인스턴스 생성 시점
	* to-be: 클래스 선언 시점
* [Rainist/styleguide](https://github.com/Rainist/styleguide/blob/master/python/README.md) 컨벤션에 맞게 수정했고 [Rainist/python](https://github.com/Rainist/python) 설정에 맞는 `black` & `isort` 스타일을 적용시켰습니다.
	* 별도의 `Makefile`을 본 PR에 포함시키진 않았습니다.
* 변경점과 관련된 에러케이스 테스트를 추가했습니다.

Resolve #11 