### PR TITLE
Support keyword arguments in init

### DIFF
--- a/kformat/kclass.py
+++ b/kformat/kclass.py
@@ -25,7 +25,7 @@ def _is_valid_child_prop(prop) -> bool:
 
 
 def _generate_args(props):
-    return ['self'] + [k for k, _ in props]
+    return ['self', *(k for k, _ in props)]
 
 
 def _generate_attributes(props):

--- a/kformat/kclass.py
+++ b/kformat/kclass.py
@@ -37,14 +37,14 @@ def _generate_attributes(props):
 
 
 def _generate_init_function(args, body):
-    locals = {}
     args = ', '.join(args)
     body = '\n'.join(f'    {b}' for b in body)
-
     txt = f'def __init__({args}):\n{body}'
-    exec(txt, {}, locals)
 
-    return locals['__init__']
+    locals_ = {}
+    exec(txt, {}, locals_)
+
+    return locals_['__init__']
 
 
 def _kclass(cls):

--- a/kformat/kclass.py
+++ b/kformat/kclass.py
@@ -5,6 +5,7 @@ __all__ = ['kclass']
 
 
 KCLASS_ANNOTATION = '__kclass__'
+_POST_INIT = '__post_init__'
 
 
 def _is_prop_kclass(prop) -> bool:
@@ -31,7 +32,7 @@ def _generate_attributes(props):
     body_lines = []
     for key, _ in props:
         body_lines.append(f'self.{key} = {key}')
-    body_lines.append(f'self.__post_init__()')
+    body_lines.append(f'self.{_POST_INIT}()')
     return body_lines
 
 
@@ -92,7 +93,7 @@ def _kclass(cls):
 
     setattr(cls, 'bytes', to_bytes)
 
-    setattr(cls, '__post_init__', post_init)
+    setattr(cls, _POST_INIT, post_init)
 
     args = _generate_args(props)
     body = _generate_attributes(props)

--- a/kformat/kclass.py
+++ b/kformat/kclass.py
@@ -23,6 +23,15 @@ def _is_valid_child_prop(prop) -> bool:
     )
 
 
+def _combine_params(props, args, kwargs):
+    for i, (field_name, field_type) in enumerate(props):
+        try:
+            value = kwargs[field_name]
+        except KeyError:
+            value = args[i]
+        yield field_name, field_type, value
+
+
 def _kclass(cls):
     setattr(cls, KCLASS_ANNOTATION, True)
 
@@ -36,10 +45,10 @@ def _kclass(cls):
     def to_bytes(self):
         return b''.join(self._bytes)
 
-    def init(self, *args):
+    def init(self, *args, **kwargs):
         prop_bytes = []
 
-        for ((k, prop), v) in zip(props, args):
+        for k, prop, v in _combine_params(props, args, kwargs):
             if _is_prop_kclass(prop):
                 if not isinstance(v, prop):
                     raise UnexpectedTypeError(prop, type(v))

--- a/tests/test_kclass.py
+++ b/tests/test_kclass.py
@@ -25,6 +25,27 @@ def test_kclass_init():
     sth = Something(123, 'k-class', Other(-456, 'subclass'), [], None)
     assert sth is not None
 
+    sth = Something(
+        n=123,
+        an='k-class',
+        other=Other(-456, 'subclass'),
+        others=[],
+        filler=None,
+    )
+    assert sth is not None
+
+    one = Other(n=123, an='1')
+    assert (one.n[1], one.an[1]) == (123, '1')
+
+    one = Other(123, an='1')
+    assert (one.n[1], one.an[1]) == (123, '1')
+
+    one = Other(an='1', n=123)
+    assert (one.n[1], one.an[1]) == (123, '1')
+
+    one = Other(123, an='1', n=456)
+    assert (one.n[1], one.an[1]) == (456, '1')
+
 
 @patch('kformat.kproperty.AN.to_bytes', lambda s, v: b'AN')
 @patch('kformat.kproperty.N.to_bytes', lambda s, v: b'N')

--- a/tests/test_kclass.py
+++ b/tests/test_kclass.py
@@ -43,8 +43,16 @@ def test_kclass_init():
     one = Other(an='1', n=123)
     assert (one.n[1], one.an[1]) == (123, '1')
 
-    one = Other(123, an='1', n=456)
-    assert (one.n[1], one.an[1]) == (456, '1')
+
+def test_too_many_argument_init_in_kclass():
+    @kclass
+    class Other:
+        n: N(5)
+        an: AN(10)
+
+    with pytest.raises(TypeError) as e:
+        one = Other(123, an='1', n=456)
+    assert str(e.value) == '__init__() got multiple values for argument \'n\''
 
 
 @patch('kformat.kproperty.AN.to_bytes', lambda s, v: b'AN')


### PR DESCRIPTION
Resolve #13, #20

## 정해야 하는 부분

아래와 같은 상황에서 error를 발생시킬 것인지 허용할 것인지 정책을 정해야합니다.

```py
one = Other(123, an='1', n=456)
assert (one.n[1], one.an[1]) == (456, '1')  # OK in K-Format?
```

보통의 경우 아래처럼 에러가 발생합니다.

```py
def func(a, b):
    return a, b

func(1, b=2, a=3)
# TypeError: func() got multiple values for argument 'a'
```
